### PR TITLE
Modifies mglPolygon to allow specification of alpha

### DIFF
--- a/mgllib/mglPolygon.c
+++ b/mgllib/mglPolygon.c
@@ -45,8 +45,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     x = (double*)mxGetPr(prhs[0]);
     y = (double*)mxGetPr(prhs[1]);
  
-
-
     // set color of points
     if (nrhs < 3)
         // set default color
@@ -54,9 +52,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     else {
       // get color
       if (mglGetColor(prhs[2],color) == 0) 
-	glColor3f(1.0,1.0,1.0);
-      else
-	glColor3f(color[0],color[1],color[2]);
+	      glColor3f(1.0,1.0,1.0);
+      else // get RGB + alpha (default 1)
+	      glColor4f(color[0],color[1],color[2], color[3]);
     }
 
 

--- a/mgllib/mglPolygon.c
+++ b/mgllib/mglPolygon.c
@@ -52,9 +52,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     else {
       // get color
       if (mglGetColor(prhs[2],color) == 0) 
-	      glColor3f(1.0,1.0,1.0);
+        glColor3f(1.0,1.0,1.0);
       else // get RGB + alpha (default 1)
-	      glColor4f(color[0],color[1],color[2], color[3]);
+        glColor4f(color[0],color[1],color[2], color[3]);
     }
 
 

--- a/mgllib/mglPolygon.c
+++ b/mgllib/mglPolygon.c
@@ -52,9 +52,9 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     else {
       // get color
       if (mglGetColor(prhs[2],color) == 0) 
-        glColor3f(1.0,1.0,1.0);
+       glColor3f(1.0,1.0,1.0);
       else // get RGB + alpha (default 1)
-        glColor4f(color[0],color[1],color[2], color[3]);
+       glColor4f(color[0],color[1],color[2], color[3]);
     }
 
 


### PR DESCRIPTION
Minor fix, replacing the use of glColor3f with glColor4f to allow specifying alpha less than 1.
- this doesn't affect the default setting since mglGetColor defines the 4th character to be 1 (opaque) if no alpha is specified.