### PR TITLE
removes dependency on mexfile for `disppercent`

### DIFF
--- a/utils/disppercent.m
+++ b/utils/disppercent.m
@@ -55,10 +55,10 @@ if (percentdone < 0)
   gDisppercent.t0 = clock;
   % default to no message
   if (nargin < 2)
-    mydisp(sprintf('00%% (00:00:00)'));
+    fprintf(1,'00%% (00:00:00)');
     gDisppercent.mesg = '';
   else
-    mydisp(sprintf('%s 00%% (00:00:00)',mesg));
+    fprintf(1,'%s 00%% (00:00:00)',mesg);
     gDisppercent.mesg = mesg;
   end    
   if isinf(percentdone)
@@ -96,7 +96,7 @@ elseif (percentdone == inf)
     timestr = sprintf('%i secs %i ms',numsecs,numms);
   end
   % display time string
-  mydisp(sprintf('\b\b\b\b\b\b\b\b\b\b\b\b\b\btook %s\n',timestr));
+  fprintf(1,'\b\b\b\b\b\b\b\b\b\b\b\b\b\btook %s\n',timestr);
   retval = elapsedTime;
 % otherwise show update
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -141,10 +141,10 @@ else
   % display percent done and estimated time to end
   if ~isempty(newmesg)
     % always display if there is a new message
-    mydisp(sprintf('\b\b\b\b\b\b\b\b\b\b\b\b\b\b%s%02i%% (%s)',newmesg,floor(100*percentdone),disptime(etime(clock,gDisppercent.t0)*(1/percentdone - 1))));
+    fprintf(1,'\b\b\b\b\b\b\b\b\b\b\b\b\b\b%s%02i%% (%s)',newmesg,floor(100*percentdone),disptime(etime(clock,gDisppercent.t0)*(1/percentdone - 1)));
   % display only if we have update by a percent or more
   elseif (gDisppercent.percentdone ~= floor(100*percentdone))
-    mydisp(sprintf('\b\b\b\b\b\b\b\b\b\b\b\b\b\b%02i%% (%s)',floor(100*percentdone),disptime(etime(clock,gDisppercent.t0)*(1/percentdone - 1))));
+    fprintf(1,'\b\b\b\b\b\b\b\b\b\b\b\b\b\b%02i%% (%s)',floor(100*percentdone),disptime(etime(clock,gDisppercent.t0)*(1/percentdone - 1)));
   end
 end
 % remember current percent done
@@ -173,12 +173,12 @@ newmesg = '';
 
 if ~strcmp(mesg,gDisppercent.mesg)
   % first clear old message
-  mydisp(sprintf('\b\b\b\b\b\b\b\b\b\b\b\b\b\b%s%s              ',repmat(sprintf('\b'),1,length(gDisppercent.mesg)+1),repmat(sprintf(' '),1,length(gDisppercent.mesg)+1)));
+  fprintf(1,'\b\b\b\b\b\b\b\b\b\b\b\b\b\b%s%s              ',repmat(sprintf('\b'),1,length(gDisppercent.mesg)+1),repmat(sprintf(' '),1,length(gDisppercent.mesg)+1));
   % print <or return> new message
   if nargout == 1
     newmesg = sprintf('%s%s ',repmat(sprintf('\b'),1,length(gDisppercent.mesg)+1),mesg);
   else
-    mydisp(sprintf('\b\b\b\b\b\b\b\b\b\b\b\b\b\b%s%s               ',repmat(sprintf('\b'),1,length(gDisppercent.mesg)+1),mesg));
+    fprintf(1,'\b\b\b\b\b\b\b\b\b\b\b\b\b\b%s%s               ',repmat(sprintf('\b'),1,length(gDisppercent.mesg)+1),mesg);
   end
   gDisppercent.mesg = mesg;
 end


### PR DESCRIPTION

as per https://github.… com/justingardner/mrTools/commit/b4330ea2b2c5. `mrTools` code relies on `disppercent` in some places, which still uses `mydisp()`. mex compiling on macOS10.15 still tricky (because of cupertino craziness and moving SDKs around)

Tested with Matlab R2016a and R2019a.